### PR TITLE
Fix build for 0.47

### DIFF
--- a/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsPackage.java
+++ b/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsPackage.java
@@ -16,7 +16,7 @@ public class ReactNativePermissionsPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new ReactNativePermissionsModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
0.47 broke a bunch of react-native packages. They all had to make this fix to work. For some reason, I missed this package, probably because it was pulling from our copy.